### PR TITLE
Add Flyway DB migrations

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     implementation("org.xerial:sqlite-jdbc:3.45.2.0")
     implementation("com.zaxxer:HikariCP:5.1.0")
 
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-community-db-support")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.mockk:mockk:1.13.10")
     testImplementation("com.ninja-squad:springmockk:4.0.2")

--- a/backend/src/main/kotlin/com/calendar/db/DatabaseFactory.kt
+++ b/backend/src/main/kotlin/com/calendar/db/DatabaseFactory.kt
@@ -3,11 +3,8 @@ package com.calendar.db
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import jakarta.annotation.PostConstruct
+import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.transactions.transaction
 import org.springframework.stereotype.Component
 
 @Component
@@ -21,12 +18,13 @@ class DatabaseFactory {
             driverClassName = "org.sqlite.JDBC"
             maximumPoolSize = 1
         }
-        Database.connect(HikariDataSource(config))
-        transaction {
-            SchemaUtils.create(EventTypes, Bookings, Settings)
-            if (Settings.selectAll().count() == 0L) {
-                Settings.insert { it[timezone] = "UTC" }
-            }
-        }
+        val dataSource = HikariDataSource(config)
+
+        Flyway.configure()
+            .dataSource(dataSource)
+            .load()
+            .migrate()
+
+        Database.connect(dataSource)
     }
 }

--- a/backend/src/main/kotlin/com/calendar/db/DatabaseFactory.kt
+++ b/backend/src/main/kotlin/com/calendar/db/DatabaseFactory.kt
@@ -17,6 +17,7 @@ class DatabaseFactory {
             jdbcUrl = "jdbc:sqlite::memory:"
             driverClassName = "org.sqlite.JDBC"
             maximumPoolSize = 1
+            connectionInitSql = "PRAGMA foreign_keys = ON"
         }
         val dataSource = HikariDataSource(config)
 

--- a/backend/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__initial_schema.sql
@@ -1,0 +1,25 @@
+CREATE TABLE event_types (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    name             VARCHAR(255) NOT NULL,
+    description      TEXT        NOT NULL,
+    duration_minutes INTEGER     NOT NULL,
+    deleted          BOOLEAN     NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE bookings (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type_id    INTEGER      NOT NULL REFERENCES event_types(id),
+    event_type_name  VARCHAR(255) NOT NULL,
+    guest_name       VARCHAR(255) NOT NULL,
+    guest_email      VARCHAR(255) NOT NULL,
+    comment          TEXT,
+    start_time       VARCHAR(50)  NOT NULL,
+    end_time         VARCHAR(50)  NOT NULL
+);
+
+CREATE TABLE settings (
+    id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    timezone VARCHAR(100) NOT NULL DEFAULT 'UTC'
+);
+
+INSERT INTO settings (timezone) VALUES ('UTC');


### PR DESCRIPTION
Implements Flyway migrations for the SQLite database, replacing the ad-hoc `SchemaUtils.create()` call with versioned SQL migration files.

Closes #4